### PR TITLE
Install with Antigen

### DIFF
--- a/pretty-time
+++ b/pretty-time
@@ -1,0 +1,1 @@
+pretty-time.zsh

--- a/pretty-time.plugin.zsh
+++ b/pretty-time.plugin.zsh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+autoload -Uz pretty-time

--- a/pretty-time.zsh
+++ b/pretty-time.zsh
@@ -2,7 +2,7 @@
 
 if (( $# == 0 )); then
 	echo 'Input required'
-	exit 1
+	return 1
 fi
 
 local human total_seconds=$1

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,18 @@
 ## Install
 
 
-Install with npm, clone this repo, or just download the [`pretty-time.zsh`](pretty-time.zsh) file.
+Install with npm or Antigen, clone this repo, or just download the [`pretty-time.zsh`](pretty-time.zsh) file.
+
+### Install with npm
 
 ```sh
 $ npm install pretty-time-zsh
+```
+
+### Install with Antigen
+
+```sh
+antigen bundle sindresorhus/pretty-time-zsh
 ```
 
 


### PR DESCRIPTION

This makes `pretty-time` installable with Antigen or Antigen-like plugin managers.

To install with Antigen for instance, add the following to `~/.zshrc` before calling `antigen apply`.

```
antigen bundle sindresorhus/pretty-time-zsh
```

Then `pretty-time` can be called as a function.

```
$ pretty-time 165392
1d 21h 56m 32s
```
